### PR TITLE
Part1: Setup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+graph-node-alternate/
+networks/testing-alt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 graph-node-alternate/
 networks/testing-alt
+.idea/

--- a/README.md
+++ b/README.md
@@ -77,3 +77,25 @@ Ex. For `v6.1.0` it is `v6.1.0-fh`
 
 Change the persistencecore image in `graph-node/firehose-node.yaml` file.  
 And run `kubectl apply`.
+
+## How to deploy a subgraph
+NOTE: Ensure you have right kubeconfig for the testnet/mainnet setup.   
+
+### Steps  
+1. Port forward below ports your local machine(same or any unused port):-   
+    a) IPFS node: port 5001   
+    b) Graph node: port 8020   
+    example cmd:
+    ```kubectl port-forward pod-name 5001:5001 --namespace graph-core-1)```   
+
+2. To deploy a subgraph with its precise name, put & execute below steps in your package.json:-   
+  ```
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "create-local": "graph create --node http://localhost:8020/ <subgraph-name>",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 <subgraph-name>",
+  ```   
+3. Check the deployed subgraphs at respective GraphiQL endpoints:-   
+GraphQL endpoint for testnet: https://graph.testnet.persistence.one   
+GraphQL endpoint for mainnet: https://graph.mainnet.persistence.one   
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Change the persistencecore image in `graph-node/firehose-node.yaml` file.
 And run `kubectl apply`.
 
 ## How to deploy a subgraph
-NOTE: Ensure you have right kubeconfig for the testnet/mainnet setup.   
+NOTE: Ensure you have right kubeconfig for the testnet/mainnet setup in Digital Ocean. Also note that this is temporary setup. We plan to implement Auth based k8s setup as possible.    
 
 ### Steps  
 1. Port forward below ports your local machine(same or any unused port):-   

--- a/base/persistencecore/genesis.yaml
+++ b/base/persistencecore/genesis.yaml
@@ -58,7 +58,7 @@ spec:
     spec:
       initContainers:
         - name: init-genesis
-          image: betterpersist/persistencecore:v6.0.0-rc12
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: COINS
@@ -152,7 +152,7 @@ spec:
               name: addresses
       containers:
         - name: validator
-          image: betterpersist/persistencecore:v6.0.0-rc12
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: CHAIN_ID

--- a/base/persistencecore/validator.yaml
+++ b/base/persistencecore/validator.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-genesis
-          image: betterpersist/persistencecore:v6.0.0-rc12
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: GENESIS_HOST
@@ -68,7 +68,7 @@ spec:
               echo "Ready to start"
               exit 0
         - name: init-validator
-          image: betterpersist/persistencecore:v6.0.0-rc12
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: CHAIN_ID

--- a/graph-node/firehose-node.yaml
+++ b/graph-node/firehose-node.yaml
@@ -152,10 +152,11 @@ spec:
             - |
               bash /scripts/init-firehose-node.sh
 
-              echo "Installing firecosmos if not already installed"
+              echo "Checking if firecosmos already installed.."
 
               # Install firecosmos if not already installed
               if [ ! -f /persistencecore/bin/firecosmos ]; then
+                echo "Installing firecosmos ..."
                 wget https://github.com/figment-networks/firehose-cosmos/releases/download/v0.6.0/firecosmos_linux_amd64 -O firecosmos
                 chmod +x firecosmos
                 mkdir -p /persistencecore/bin

--- a/graph-node/firehose-node.yaml
+++ b/graph-node/firehose-node.yaml
@@ -52,9 +52,10 @@ spec:
         app.kubernetes.io/name: persistencecore-firehose-node
         app.kubernetes.io/version: '0.1'
     spec:
+      terminationGracePeriodSeconds: 10
       initContainers:
         - name: wait-for-genesis
-          image: registry.digitalocean.com/nevermore/persistence:v6.1.0-fh
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: GENESIS_NODE_DATA_RESOLUTION_METHOD
@@ -86,7 +87,7 @@ spec:
               echo "Ready to start"
               exit 0
         - name: init-firehose-node
-          image: registry.digitalocean.com/nevermore/persistence:v6.1.0-fh
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: CHAIN_ID
@@ -135,7 +136,7 @@ spec:
                 configMapKeyRef:
                   key: seeds
                   name: firehose-node-config
-            - name: FIRST_STREAMABLE_BLOCK
+            - name: FIRST_STREAMBLE_BLOCK
               valueFrom:
                 configMapKeyRef:
                   key: first_streamable_block
@@ -150,6 +151,16 @@ spec:
             - "-c"
             - |
               bash /scripts/init-firehose-node.sh
+
+              echo "Installing firecosmos if not already installed"
+
+              # Install firecosmos if not already installed
+              if [ ! -f /persistencecore/bin/firecosmos ]; then
+                wget https://github.com/figment-networks/firehose-cosmos/releases/download/v0.6.0/firecosmos_linux_amd64 -O firecosmos
+                chmod +x firecosmos
+                mkdir -p /persistencecore/bin
+                mv firecosmos /persistencecore/bin/firecosmos
+              fi
           resources:
             limits:
               cpu: "1"
@@ -166,7 +177,7 @@ spec:
               name: scripts-graph
       containers:
         - name: firehose-node
-          image: registry.digitalocean.com/nevermore/persistence:v6.1.0-fh
+          image: docker.io/persistenceone/persistencecore:v7.0.0-fh
           imagePullPolicy: Always
           env:
             - name: CHAIN_ID
@@ -180,21 +191,14 @@ spec:
             - bash
             - "-c"
             - |
-              echo "Installing firecosmos"
-              wget https://github.com/figment-networks/firehose-cosmos/releases/download/v0.6.0/firecosmos_linux_amd64 -O firecosmos
-              chmod +x firecosmos
-              mv firecosmos /usr/local/bin
-
-              echo "starting firehose with persistence core"
-              # sleep infinity
-              firecosmos start --config $HOME_DIR/config/firehose.yml --data-dir /fh-data
+              exec /persistencecore/bin/firecosmos start --config /persistencecore/config/firehose.yml --data-dir /fh-data 
           resources:
             limits:
-              cpu: "2"
-              memory: "4G"
+              cpu: "4"
+              memory: "7G"
             requests:
-              cpu: "1"
-              memory: "3G"
+              cpu: "3"
+              memory: "6G"
           volumeMounts:
             - mountPath: /persistencecore
               name: node-pv-storage

--- a/graph-node/firehose-node.yaml
+++ b/graph-node/firehose-node.yaml
@@ -211,18 +211,12 @@ spec:
         - name: firehose-pv-storage
           persistentVolumeClaim:
             claimName: firehose-pv-claim
+        - name: node-pv-storage
+          persistentVolumeClaim:
+            claimName: node-pv-claim
         - name: config-graph
           configMap:
             name: config-graph
         - name: scripts-graph
           configMap:
             name: scripts-graph
-  volumeClaimTemplates:
-  - metadata:
-      name: node-pv-storage
-    spec:
-      storageClassName: do-block-storage
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 30Gi

--- a/graph-node/firehose-node.yaml
+++ b/graph-node/firehose-node.yaml
@@ -136,7 +136,7 @@ spec:
                 configMapKeyRef:
                   key: seeds
                   name: firehose-node-config
-            - name: FIRST_STREAMBLE_BLOCK
+            - name: FIRST_STREAMABLE_BLOCK
               valueFrom:
                 configMapKeyRef:
                   key: first_streamable_block

--- a/graph-node/firehose-persistent-volume.yaml
+++ b/graph-node/firehose-persistent-volume.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi

--- a/graph-node/firehose-persistent-volume.yaml
+++ b/graph-node/firehose-persistent-volume.yaml
@@ -9,3 +9,16 @@ spec:
   resources:
     requests:
       storage: 20Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: node-pv-claim
+spec:
+  storageClassName: do-block-storage
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi

--- a/graph-node/graph-node.yaml
+++ b/graph-node/graph-node.yaml
@@ -88,7 +88,7 @@ spec:
 
       containers:
         - name: graph-node
-          image: graphprotocol/graph-node:latest
+          image: graphprotocol/graph-node:v0.29.0
           imagePullPolicy: Always
           env:
             - name: FIREHOSE_HOST
@@ -166,10 +166,10 @@ spec:
           resources:
             limits:
               cpu: "2"
-              memory: "4G"
+              memory: "2G"
             requests:
               cpu: "1"
-              memory: "2G"
+              memory: "1G"
           volumeMounts:
             - mountPath: config-graph
               name: config-graph

--- a/graph-node/hasura.yaml
+++ b/graph-node/hasura.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: hasura
-          image: hasura/graphql-engine:v2.2.0
+          image: hasura/graphql-engine:v2.19.0
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -39,8 +39,15 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: POSTGRES_FULL_URL
+                  key: POSTGRES_HASURA_URL
             - name: HASURA_GRAPHQL_ENABLE_CONSOLE
               value: 'true'
             - name: HASURA_GRAPHQL_DEV_MODE
               value: 'true'
+            - name: HASURA_GRAPHQL_ADMIN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: HASURA_GRAPHQL_ADMIN_SECRET
+            - name: HASURA_GRAPHQL_UNAUTHORIZED_ROLE
+              value: api-user

--- a/graph-node/kustomization.yaml
+++ b/graph-node/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - firehose-node.yaml
   - graph-node.yaml
   - ipfs-node.yaml
-  # - hasura.yaml
+  - hasura.yaml
   - ipfs-persistent-volume.yaml
   - firehose-persistent-volume.yaml
 

--- a/graph-node/kustomization.yaml
+++ b/graph-node/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - firehose-node.yaml
   - graph-node.yaml
   - ipfs-node.yaml
-  - hasura.yaml
+ # - hasura.yaml
   - ipfs-persistent-volume.yaml
   - firehose-persistent-volume.yaml
 

--- a/graph-node/scripts/init-firehose-node.sh
+++ b/graph-node/scripts/init-firehose-node.sh
@@ -79,7 +79,7 @@ END
     # update the minimum-gas-prices in app.toml to 100uxprt
     sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "100uxprt"/g' $HOME_DIR/config/app.toml
 
-    # if STATE_RESTORE_SNAPSHOT_URL is not empty url and wasm folder doesn't exist, then download and extract the snapshot
+    # if STATE_RESTORE_SNAPSHOT_URL is not empty url, then download and extract the snapshot
     if [ ! -z "$STATE_RESTORE_SNAPSHOT_URL" ]; then
         echo "=> Downloading snapshot from $STATE_RESTORE_SNAPSHOT_URL"
         FILENAME=$(basename $STATE_RESTORE_SNAPSHOT_URL)

--- a/graph-node/scripts/init-firehose-node.sh
+++ b/graph-node/scripts/init-firehose-node.sh
@@ -41,10 +41,11 @@ else
         curl $GENESIS_JSON_FETCH_URL -o $HOME_DIR/config/genesis.json
     fi
 
+    GENESIS_NODE_P2P="$GENESIS_NODE_ID@$GENESIS_HOST:$GENESIS_PORT_P2P"
+    echo "Node P2P: $GENESIS_NODE_P2P"
+
     # skip persistent_peers if GENESIS_NODE_DATA_RESOLUTION_METHOD is static
     if [ $GENESIS_NODE_DATA_RESOLUTION_METHOD = "DYNAMIC" ]; then
-        GENESIS_NODE_P2P="$GENESIS_NODE_ID@$GENESIS_HOST:$GENESIS_PORT_P2P"
-        echo "Node P2P: $GENESIS_NODE_P2P"
         sed -i "s/persistent_peers = \"\"/persistent_peers = \"$GENESIS_NODE_P2P\"/g" $HOME_DIR/config/config.toml
     fi
     sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' $HOME_DIR/config/config.toml
@@ -72,23 +73,45 @@ END
 
     echo "Setting up pruning configuration in app.toml"
     sed -i 's/pruning = "default"/pruning = "custom"/g' $HOME_DIR/config/app.toml
-    sed -i 's/pruning-interval = "0"/pruning-interval = "10"/g' $HOME_DIR/config/app.toml
-    sed -i 's/pruning-keep-recent = "0"/pruning-keep-recent = "100"/g' $HOME_DIR/config/app.toml
+    sed -i 's/pruning-interval = "0"/pruning-interval = "100"/g' $HOME_DIR/config/app.toml
+    sed -i 's/pruning-keep-recent = "0"/pruning-keep-recent = "10000"/g' $HOME_DIR/config/app.toml
 
-    echo "Printing app.toml"
-    cat $HOME_DIR/config/app.toml
+    # update the minimum-gas-prices in app.toml to 100uxprt
+    sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "100uxprt"/g' $HOME_DIR/config/app.toml
 
-    # Restore snapshot if url is present
+    # if STATE_RESTORE_SNAPSHOT_URL is not empty url and wasm folder doesn't exist, then download and extract the snapshot
     if [ ! -z "$STATE_RESTORE_SNAPSHOT_URL" ]; then
-        echo "Downloading snapshot from $STATE_RESTORE_SNAPSHOT_URL"
-        wget -O $HOME_DIR/snapshot.tar.gz $STATE_RESTORE_SNAPSHOT_URL
+        echo "=> Downloading snapshot from $STATE_RESTORE_SNAPSHOT_URL"
+        FILENAME=$(basename $STATE_RESTORE_SNAPSHOT_URL)
+        curl $STATE_RESTORE_SNAPSHOT_URL -o $HOME_DIR/$FILENAME
 
-        echo "Extracting snapshot"
-        tar -xvf $HOME_DIR/snapshot.tar.gz -C $HOME_DIR
-        rm -rf $HOME_DIR/snapshot.tar.gz
+        echo "=> Extracting snapshot"
+        cp $HOME_DIR/data/priv_validator_state.json $HOME/priv_validator_state_backup.json
+
+        case "$FILENAME" in
+            *.tar.lz4)
+                if ! command -v lz4 &> /dev/null; then
+                    apk add --no-cache lz4
+                fi
+
+                lz4 -c -d $HOME_DIR/$FILENAME | tar -x -C $HOME_DIR
+                # delete the $HOME_DIR/wasm/wasm/cache folder
+                rm -rf $HOME_DIR/wasm/wasm/cache
+                rm -rf $HOME_DIR/$FILENAME
+                ;;
+
+            *.tar.gz)
+                tar -xvf $HOME_DIR/$FILENAME -C $HOME_DIR
+                rm -rf $HOME_DIR/wasm/wasm/cache
+                rm -rf $HOME_DIR/$FILENAME
+                ;;
+        esac
+
+        cp $HOME_DIR/priv_validator_state_backup.json $HOME/data/priv_validator_state.json
+        rm $HOME_DIR/priv_validator_state_backup.json
     fi
-fi
 
+fi
 # copy the firehose.yml file to the HOME_DIR because config-graph is a read-only volume
 cp /config-graph/firehose.yml $HOME_DIR/config/firehose.yml
 

--- a/networks/devnet/configmap.yaml
+++ b/networks/devnet/configmap.yaml
@@ -20,7 +20,7 @@ data:
   seeds: ''
   # For buffer time to sync the node
   first_streamable_block: '300'
-  force_init: 'true'
+  force_init: 'false'
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/networks/devnet/ingress.yaml
+++ b/networks/devnet/ingress.yaml
@@ -82,6 +82,9 @@ metadata:
   name: ingress-core-devnet-graph
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.org/websocket-services: "persistencecore-graph-node"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
     - secretName: cloudflare-tls
@@ -91,11 +94,18 @@ spec:
     - host: graph.devnet.core.dexter.zone
       http:
         paths:
-          - path: /
+          - path: /()(.*)
             pathType: Prefix
             backend:
               service:
                 name: persistencecore-graph-node
                 port:
                   number: 8000
+          - path: /ws(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: persistencecore-graph-node
+                port:
+                  number: 8001
   ingressClassName: nginx

--- a/networks/mainnet/configmap.yaml
+++ b/networks/mainnet/configmap.yaml
@@ -29,7 +29,7 @@ kind: ConfigMap
 metadata:
   name: graph-node-config
 data:
-  firehose_node.host: 'persistencecore-firehose-node.mainnet.svc.cluster.local'
+  firehose_node.host: 'persistencecore-firehose-node.graph-core-1.svc.cluster.local'
   firehose_node.port: '9030'
-  ipfs.host: 'ipfs-node.mainnet.svc.cluster.local'
+  ipfs.host: 'ipfs-node.graph-core-1.svc.cluster.local'
   ipfs.port: '5001'

--- a/networks/mainnet/configmap.yaml
+++ b/networks/mainnet/configmap.yaml
@@ -16,9 +16,11 @@ data:
   sync_node.exposer_port: ''
   sync_node.port_p2p: '26656'
   sync_node.genesis_json_fetch_url: 'https://raw.githubusercontent.com/persistenceOne/networks/master/core-1/final_genesis.json'
-  snapshot_restore_url: 'https://tools.highstakes.ch/files/persistence/data_2023-01-11.tar.gz' # block height 9597501
+  snapshot_restore_url: 'https://files.audit.one/persistence/snapshot/data_height_10522614.tar.lz4'
+  # seeds: 'fbf0aa94b512902a249b246ed5763b50df9c0543@seed.core.persistence.one:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:15456,ebc272824924ea1a27ea3183dd0b9ba713494f83@persistence-mainnet-seed.autostake.com:26896'
   seeds: 'fbf0aa94b512902a249b246ed5763b50df9c0543@seed.core.persistence.one:26656'
-  first_streamable_block: '9597600'
+  # For buffer time to sync the node
+  first_streamable_block: '10522616'
   force_init: 'false'
 
 ---
@@ -27,7 +29,7 @@ kind: ConfigMap
 metadata:
   name: graph-node-config
 data:
-  firehose_node.host: 'persistencecore-firehose-node.graph-core-1.svc.cluster.local'
+  firehose_node.host: 'persistencecore-firehose-node.mainnet.svc.cluster.local'
   firehose_node.port: '9030'
-  ipfs.host: 'ipfs-node.graph-core-1.svc.cluster.local'
+  ipfs.host: 'ipfs-node.mainnet.svc.cluster.local'
   ipfs.port: '5001'

--- a/networks/mainnet/ingress.yaml
+++ b/networks/mainnet/ingress.yaml
@@ -1,41 +1,31 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-core-testnet-graph
+  name: ingress-core-mainnet-graph
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.org/websocket-services: "persistencecore-graph-node"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
     - secretName: cloudflare-tls
       hosts:
-        - graph.testnet.dexter.zone
+        - graph.core-1.dexter.zone
   rules:
-    - host: graph.testnet.dexter.zone
+    - host: graph.core-1.dexter.zone
       http:
         paths:
-          - path: /()(.*)
+          - path: /
             pathType: Prefix
             backend:
               service:
                 name: persistencecore-graph-node
                 port:
                   number: 8000
-          - path: /ws(/|$)(.*)
-            pathType: Prefix
-            backend:
-              service:
-                name: persistencecore-graph-node
-                port:
-                  number: 8001
   ingressClassName: nginx
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-core-testnet-hasura
+  name: ingress-core-mainnet-hasura
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -43,9 +33,9 @@ spec:
   tls:
     - secretName: cloudflare-tls
       hosts:
-        - api.testnet.dexter.zone
+        - api.core-1.dexter.zone
   rules:
-    - host: api.testnet.dexter.zone
+    - host: api.core-1.dexter.zone
       http:
         paths:
           - path: /

--- a/networks/mainnet/ingress.yaml
+++ b/networks/mainnet/ingress.yaml
@@ -1,16 +1,16 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-core-mainnet-graph
+  name: ingress-graph-mainnet-persistence
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   tls:
     - secretName: cloudflare-tls
       hosts:
-        - graph.core-1.dexter.zone
+        - graph.mainnet.persistence.one
   rules:
-    - host: graph.core-1.dexter.zone
+    - host: graph.mainnet.persistence.one
       http:
         paths:
           - path: /
@@ -20,29 +20,4 @@ spec:
                 name: persistencecore-graph-node
                 port:
                   number: 8000
-  ingressClassName: nginx
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress-core-mainnet-hasura
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-spec:
-  tls:
-    - secretName: cloudflare-tls
-      hosts:
-        - api.core-1.dexter.zone
-  rules:
-    - host: api.core-1.dexter.zone
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: persistencecore-hasura
-                port:
-                  number: 8080
   ingressClassName: nginx

--- a/networks/mainnet/kustomization.yaml
+++ b/networks/mainnet/kustomization.yaml
@@ -1,6 +1,6 @@
-namespace: mainnet
+namespace: graph-core-1
 
 resources:
-  - ingress.yaml
+#  - ingress.yaml
   - ../../graph-node
   - configmap.yaml

--- a/networks/mainnet/kustomization.yaml
+++ b/networks/mainnet/kustomization.yaml
@@ -1,6 +1,6 @@
 namespace: graph-core-1
 
 resources:
-#  - ingress.yaml
+  - ingress.yaml
   - ../../graph-node
   - configmap.yaml

--- a/networks/mainnet/kustomization.yaml
+++ b/networks/mainnet/kustomization.yaml
@@ -1,6 +1,6 @@
-namespace: graph-core-1
+namespace: mainnet
 
 resources:
-  # - ingress.yaml
-  - configmap.yaml
+  - ingress.yaml
   - ../../graph-node
+  - configmap.yaml

--- a/networks/testnet/configmap.yaml
+++ b/networks/testnet/configmap.yaml
@@ -16,10 +16,10 @@ data:
   sync_node.exposer_port: ''
   sync_node.port_p2p: '26656'
   sync_node.genesis_json_fetch_url: 'https://raw.githubusercontent.com/persistenceOne/networks/master/test-core-1/final_genesis.json'
-  snapshot_restore_url: 'https://tendermint-snapshots.s3.ap-southeast-1.amazonaws.com/persistence/testnet/test.tar.gz'
+  snapshot_restore_url: 'https://nevermore.sgp1.digitaloceanspaces.com/persistence%2Fsnapshot%2Ftestnet%2Ftestnet_10750519.tar.lz4'
   seeds: 'b4237f8a7ca357d380ad119b76cbceec7e7e8a75@seed.testnet.persistence.one:26656'
   # For buffer time to sync the node
-  first_streamable_block: '9292200'
+  first_streamable_block: '10750521'
   force_init: 'false'
 
 ---

--- a/networks/testnet/configmap.yaml
+++ b/networks/testnet/configmap.yaml
@@ -12,12 +12,12 @@ metadata:
   name: firehose-node-config
 data:
   sync_node.resolution_method: STATIC
-  sync_node.host: '3.34.2.126'
+  sync_node.host: ''
   sync_node.exposer_port: ''
   sync_node.port_p2p: '26656'
   sync_node.genesis_json_fetch_url: 'https://raw.githubusercontent.com/persistenceOne/networks/master/test-core-1/final_genesis.json'
   snapshot_restore_url: 'https://tendermint-snapshots.s3.ap-southeast-1.amazonaws.com/persistence/testnet/test.tar.gz'
-  seeds: 'b4237f8a7ca357d380ad119b76cbceec7e7e8a75@128.199.218.4:26656'
+  seeds: 'b4237f8a7ca357d380ad119b76cbceec7e7e8a75@seed.testnet.persistence.one:26656'
   # For buffer time to sync the node
   first_streamable_block: '9292200'
   force_init: 'false'
@@ -28,7 +28,7 @@ kind: ConfigMap
 metadata:
   name: graph-node-config
 data:
-  firehose_node.host: 'persistencecore-firehose-node.testnet.svc.cluster.local'
+  firehose_node.host: 'persistencecore-firehose-node.graph-test-core-1.svc.cluster.local'
   firehose_node.port: '9030'
-  ipfs.host: 'ipfs-node.testnet.svc.cluster.local'
+  ipfs.host: 'ipfs-node.graph-test-core-1.svc.cluster.local'
   ipfs.port: '5001'

--- a/networks/testnet/configmap.yaml
+++ b/networks/testnet/configmap.yaml
@@ -12,18 +12,10 @@ metadata:
   name: firehose-node-config
 data:
   sync_node.resolution_method: STATIC
-  sync_node.host: ''
+  sync_node.host: '3.34.2.126'
   sync_node.exposer_port: ''
   sync_node.port_p2p: '26656'
   sync_node.genesis_json_fetch_url: 'https://raw.githubusercontent.com/persistenceOne/networks/master/test-core-1/final_genesis.json'
-  # TODO: change to v6 snapshot
-  # snapshot dir structure should follow
-  # root
-  #   - data
-  #     - application.db
-  #     - blockstore.db
-  #     - ...
-  #   - wasm
   snapshot_restore_url: 'https://tendermint-snapshots.s3.ap-southeast-1.amazonaws.com/persistence/testnet/test.tar.gz'
   seeds: 'b4237f8a7ca357d380ad119b76cbceec7e7e8a75@128.199.218.4:26656'
   # For buffer time to sync the node

--- a/networks/testnet/ingress.yaml
+++ b/networks/testnet/ingress.yaml
@@ -1,58 +1,23 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress-core-testnet-graph
+  name: ingress-graph-testnet-persistence
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.org/websocket-services: "persistencecore-graph-node"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   tls:
-    - secretName: cloudflare-tls
+    - secretName: cloudflare-tls-graph-testnet
       hosts:
-        - graph.testnet.dexter.zone
+        - graph.testnet.persistence.one
   rules:
-    - host: graph.testnet.dexter.zone
-      http:
-        paths:
-          - path: /()(.*)
-            pathType: Prefix
-            backend:
-              service:
-                name: persistencecore-graph-node
-                port:
-                  number: 8000
-          - path: /ws(/|$)(.*)
-            pathType: Prefix
-            backend:
-              service:
-                name: persistencecore-graph-node
-                port:
-                  number: 8001
-  ingressClassName: nginx
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress-core-testnet-hasura
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-spec:
-  tls:
-    - secretName: cloudflare-tls
-      hosts:
-        - api.testnet.dexter.zone
-  rules:
-    - host: api.testnet.dexter.zone
+    - host: graph.testnet.persistence.one
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: persistencecore-hasura
+                name: persistencecore-graph-node
                 port:
-                  number: 8080
+                  number: 8000
   ingressClassName: nginx

--- a/networks/testnet/kustomization.yaml
+++ b/networks/testnet/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: testnet
+namespace: graph-test-core-1
 
 resources:
   - ingress.yaml


### PR DESCRIPTION
1. Firecosmos process started using exec (not as a sub-shell process)
2. Graph node version: v0.29.0 because of 2 reasons:
    - Latest version(v0.30.0) does not allow Firehose-based block ingestor to switch back to RPC in case of any issue
    - Latest version installations mandate PostgreSQL to use C locale and basic POSIX style Collate (whereas PostgresSQL installations allow database creation by default with en_US.UTF-8, this can be managed with docker installations or some other hack)
3. node-pv-storage created as PersistentVolumeClaim and not from template
4. Snapshot extraction steps added for lz4  
5. Websocket endpoint for testnet 
6. DNS ingress(w/o hasura) added for mainnet & testnet GraphiQL endpoints
7. Firehose pod resource limits increased to avoid OOM
    NOTE: When a container or pod is terminated due to OOMKilled, Kubernetes immediately sends a SIGKILL signal, without using SIGTERM and without using a grace period. In other cases when SIGTERM is sent, grace period is applicable and is currently set to 10 seconds < default value 30 seconds
9. Subgraph deploy steps added in the README 